### PR TITLE
adding feature to suppor cache entry delete

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -181,6 +181,29 @@ void cache_set(const char *key,unsigned int keylen,const char *data,unsigned int
   cache_motion += entrylen;
 }
 
+
+int cache_del(const char *key,unsigned int keylen)
+{
+  uint32 prevpos;
+  uint32 pos;
+  unsigned int keyhash;
+
+  if (!x) return 0;
+  if (keylen > MAXKEYLEN) return 0;
+
+  keyhash = hash(key,keylen);
+  pos = get4(keyhash);
+  if (pos) {
+      prevpos = get4(pos) ^ keyhash;
+      set4(keyhash, prevpos);
+      if (prevpos)  {
+          set4(prevpos, get4(prevpos) ^ keyhash ^ pos);
+      }
+      return 1;
+  }
+  return 0; 
+}
+
 int cache_init(unsigned int cachesize)
 {
   if (x) {

--- a/cache.h
+++ b/cache.h
@@ -8,5 +8,6 @@ extern uint64 cache_motion;
 extern int cache_init(unsigned int);
 extern void cache_set(const char *,unsigned int,const char *,unsigned int,uint32);
 extern char *cache_get(const char *,unsigned int,unsigned int *,uint32 *);
+extern int cache_del(const char *,unsigned int );
 
 #endif

--- a/cachetest.c
+++ b/cachetest.c
@@ -6,6 +6,7 @@
 int main(int argc,char **argv)
 {
   int i;
+  int j;
   char *x;
   char *y;
   unsigned int u;
@@ -17,8 +18,12 @@ int main(int argc,char **argv)
 
   while (x = *argv++) {
     i = str_chr(x,':');
+    j = str_chr(x,'-');
     if (x[i])
       cache_set(x,i,x + i + 1,str_len(x) - i - 1,86400);
+    else if (x[j]) {
+      cache_del(x,j);
+    }
     else {
       y = cache_get(x,i,&u,&ttl);
       if (y)


### PR DESCRIPTION
- Deletes an entry from cache
- Tests Run using cachetest tool.
- cachetest command line now takes "<key>-" to  trigger delete operation


Tests ran:

1. Deleting after adding single entry 

tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100 k1- k1

tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100  k1
100
2.1 Deleting after adding mutiple entries with same key
tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100  k1:200 k1- k1
100

2.2  
tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100  k1:200 k1:300 k1- k1
200
2.3 
tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100  k1:200 k1:300 k1- k1- k1
100
tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100  k1:200 k1:300 k1- k1- k1- k1

3. Trying combination with multiple entries with different keys
tmizan@tmizan-VirtualBox:/u02/tests/github/dnscache-tm$ ./cachetest k1:100  k1:200 k1:300 k2:100 k1- k1- k1- k1 k2

100

